### PR TITLE
Fixed audio stopping in browser after audio context limit reached

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -19,13 +19,16 @@ interface Window {
  * @param {Number} panVal value for either left or right channel
  * @returns None
  */
+
+//create audio context a single time 
+const audioCtx = new (window.AudioContext || window.webkitAudioContext)();
+
 function beep(panVal: number) {
     // audio disabled?
     if (!$("#soundSettings").data("bool")) {
         return;
     }
-    // create the audio context
-    const audioCtx = new (window.AudioContext || window.webkitAudioContext)();
+
     // create the things ball.ballPosition am using to manipulate the beeps
     const oscillator = audioCtx.createOscillator();
     const panNode = audioCtx.createStereoPanner();


### PR DESCRIPTION
Found out what the issue was with the audio stopping

Since the beep function was creating a context every time the function was called , chrome would block the context creation after a while.

Changed the code so that it only creates the context once.